### PR TITLE
Fix widget touch sensitivity (#2)

### DIFF
--- a/ui-src/src/list/ListItem.vue
+++ b/ui-src/src/list/ListItem.vue
@@ -6,7 +6,22 @@
             completable && $style.isCompletable,
             tappable && $style.isTappable
         ]">
+        <div
+            v-if="completable"
+            :class="$style.listItemCheckable"
+            data-checkable>
+            <Transition
+                mode="out-in"
+                name="check">
+                <Icon
+                    :key="icon"
+                    :class="$style.listItemIcon"
+                    :icon="icon"/>
+            </Transition>
+        </div>
+
         <Transition
+            v-else
             mode="out-in"
             name="check">
             <Icon
@@ -62,7 +77,7 @@
         transition: 150ms var(--swift-out);
         z-index: 0;
 
-        &.isTappable:not(:has([data-interactive]:active)):active {
+        &.isTappable:has([data-checkable]:active) {
             background: var(--homey-color-mono-050);
             scale: .975;
         }
@@ -73,6 +88,15 @@
         flex-flow: column;
         flex-grow: 1;
         gap: var(--homey-su-2);
+    }
+
+    .listItemCheckable {
+        display: flex;
+        margin: calc(-1 * var(--homey-su-4));
+        margin-right: 0;
+        padding: var(--homey-su-4);
+        align-items: flex-start;
+        cursor: pointer;
     }
 
     .listItemIcon {
@@ -112,7 +136,7 @@
     :global(.homey-dark-mode) .listItem {
         background: rgb(from var(--homey-color-mono-100) r g b / .5);
 
-        &.isTappable:not(:has([data-interactive]:active)):active {
+        &.isTappable:has([data-checkable]:active) {
             background: var(--homey-color-mono-100);
         }
     }

--- a/ui-src/src/list/ListItemMount.vue
+++ b/ui-src/src/list/ListItemMount.vue
@@ -60,7 +60,9 @@
     const currentX = ref(0);
     const currentY = ref(0);
     const isTap = ref(true);
+    const touchedCheckable = ref(false);
     const touchedInteractive = ref(false);
+    const lockedDirection = ref<'horizontal' | 'vertical' | null>(null);
     const longPressTimer = ref<ReturnType<typeof setTimeout> | null>(null);
     const didLongPress = ref(false);
 
@@ -122,8 +124,11 @@
         isDragging.value = true;
         isTap.value = true;
         didLongPress.value = false;
+        lockedDirection.value = null;
 
-        touchedInteractive.value = (evt.target as HTMLElement).closest('[data-interactive]') !== null;
+        const target = evt.target as HTMLElement;
+        touchedCheckable.value = target.closest('[data-checkable]') !== null;
+        touchedInteractive.value = target.closest('[data-interactive]') !== null;
 
         clearLongPressTimer();
 
@@ -150,12 +155,26 @@
         const deltaX = Math.abs(currentX.value - startX.value);
         const deltaY = Math.abs(currentY.value - startY.value);
 
-        if (deltaX > 10 || deltaY > 10) {
+        // Lock direction once sufficient movement is detected.
+        if (!unref(lockedDirection) && (deltaX > 15 || deltaY > 15)) {
+            lockedDirection.value = deltaX > deltaY ? 'horizontal' : 'vertical';
+        }
+
+        if (deltaX > 20 || deltaY > 20) {
             isTap.value = false;
             clearLongPressTimer();
         }
 
-        if (deltaX > deltaY && deltaX > 15) {
+        // For vertical scrolling, release touch handling and let the
+        // browser handle the scroll natively.
+        if (unref(lockedDirection) === 'vertical') {
+            isDragging.value = false;
+            clearLongPressTimer();
+            return;
+        }
+
+        // For horizontal swiping, prevent native scroll.
+        if (unref(lockedDirection) === 'horizontal') {
             evt.preventDefault();
         }
     }
@@ -188,7 +207,7 @@
 
         const deltaX = startX.value - currentX.value;
 
-        if (unref(isTap) && !unref(touchedInteractive) && !unref(didLongPress)) {
+        if (unref(isTap) && !unref(touchedInteractive) && !unref(didLongPress) && unref(touchedCheckable)) {
             emit('tap');
             return;
         }
@@ -198,7 +217,7 @@
             return;
         }
 
-        isOpen.value = deltaX > 45;
+        isOpen.value = deltaX > 70;
     }
 
     watch(isOpen, (open, _, onCleanup) => {


### PR DESCRIPTION
## Summary

Fixes #2 — the widget touch controls were too sensitive, causing accidental check-offs and making scrolling difficult (especially on Android).

- **Check/uncheck only via checkbox icon** — tapping the text content or body of an item no longer toggles the checked state. Only tapping the icon/checkbox area does. The checkable area has a generous tap target (extends to the item edge via negative margin).
- **Direction locking** — once the user starts moving vertically (scroll) or horizontally (swipe), the direction is locked. Vertical movement releases touch handling so the browser handles scrolling natively, preventing the "can't scroll without checking off" issue.
- **Higher tap threshold** — increased from 10px to 20px to account for Android touch jitter that caused taps to register during scroll attempts.
- **Higher swipe-open threshold** — increased from 45px to 70px to prevent accidental delete button reveals during vertical scrolling with slight horizontal drift.
- **Correct active state feedback** — the press highlight now only shows when the checkable area is touched, not when pressing the item body.

## Test plan

- [ ] Tap the checkbox/icon area of a task or product → should toggle checked
- [ ] Tap the text content of a task or product → should NOT toggle checked
- [ ] Long-press anywhere on an item → should still open the edit form
- [ ] Scroll vertically through a long list → should scroll smoothly without toggling items or revealing delete buttons
- [ ] Swipe left on an item → should reveal delete button (needs clear horizontal intent)
- [ ] Test on Android phone/tablet specifically
- [ ] Test on iOS
- [ ] Verify quantity +/- buttons on products still work